### PR TITLE
Use latest bundler

### DIFF
--- a/danger-android_permissions_checker.gemspec
+++ b/danger-android_permissions_checker.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'danger-plugin-api', '~> 1.0'
 
   # General ruby development
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 1.3'
   spec.add_development_dependency 'rake', '~> 10.0'
 
   # Testing support


### PR DESCRIPTION
This library depends on bundler in development, but no need to use only bundler 1.X.